### PR TITLE
Allow passing AST Tree directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ obfuscation-detector --help
 - **stopAfterFirst**: If `true`, returns after the first positive detection (default). If `false`, returns all detected types.
 - **Returns**: An array of detected obfuscation type names. Returns an empty array if no known type is detected.
 
+### `detectObfuscationFlatAST(tree: ASTNode[], stopAfterFirst: boolean = true): string[]`
+- **code**: JavaScript source code as an AST Tree; returned by flast's generateFlatAST.
+- **stopAfterFirst**: If `true`, returns after the first positive detection (default). If `false`, returns all detected types.
+- **Returns**: An array of detected obfuscation type names. Returns an empty array if no known type is detected.
+
 ## Supported Obfuscation Types
 Descriptions and technical details for each type are available in [src/detectors/README.md](src/detectors/README.md):
 - [Array Replacements](src/detectors/arrayReplacements.js)

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,13 @@ import * as detectors from './detectors/index.js';
 /**
  * Detects obfuscation types in JavaScript code by analyzing its AST.
  *
- * @param {string} code - The JavaScript source code to analyze.
+ * @param {ASTNode[]} tree - Existing AST tree from generateFlatAST to analyze.
  * @param {boolean} [stopAfterFirst=true] - If true, returns after the first positive detection; if false, returns all matches.
  * @returns {string[]} An array of detected obfuscation type names. Returns an empty array if no known type is detected.
  */
-function detectObfuscation(code, stopAfterFirst = true) {
+function detectObfuscationFlatAST(tree, stopAfterFirst = true) {
 	const detectedObfuscations = [];
 	try {
-		const tree = generateFlatAST(code);
 		for (const detectorName of Object.keys(detectors)) {
 			try {
 				const detectionType = detectors[detectorName](tree, detectedObfuscations);
@@ -35,4 +34,22 @@ function detectObfuscation(code, stopAfterFirst = true) {
 	return detectedObfuscations;
 }
 
-export {detectObfuscation};
+
+/**
+ * Detects obfuscation types in JavaScript code by analyzing its AST.
+ *
+ * @param {string} code - The JavaScript source code to analyze.
+ * @param {boolean} [stopAfterFirst=true] - If true, returns after the first positive detection; if false, returns all matches.
+ * @returns {string[]} An array of detected obfuscation type names. Returns an empty array if no known type is detected.
+ */
+function detectObfuscation(code, stopAfterFirst = true) {
+	let tree;
+	try {
+		tree = generateFlatAST(code);
+	} catch (e) {
+		logger.debug(e.message);	// Keep for debugging
+	}
+	return detectObfuscationFlatAST(tree, stopAfterFirst);
+}
+
+export {detectObfuscation, detectObfuscationFlatAST};


### PR DESCRIPTION
[Related PR](https://github.com/HumanSecurity/flast/pull/45)

This PR is part of a set to allow for restringer to avoid recomputing the same flast to improve performance when working on large js files.

```
❯ npm run test

> obfuscation-detector@2.0.7 test
> node --test

▶ Detectors tests
  ✔ array_function_replacements_local_proxies (54.571507ms)
  ✔ array_replacements (10.816383ms)
  ✔ array_replacements_prototype_calls (8.661569ms)
  ✔ augmented_array_function_replacements (44.645347ms)
  ✔ augmented_proxied_array_function_replacements (166.253226ms)
  ✔ caesar_plus (5.681033ms)
  ✔ obfuscator.io-NotBooleanTilde (7.973299ms)
  ✔ obfuscator.io-setCookie (6.55019ms)
✔ Detectors tests (306.126756ms)
▶ Functionality
  ✔ Invalid input should not throw an error (4.421038ms)
  ✔ Invalid input should return an empty array (0.825095ms)
✔ Functionality (5.92106ms)
ℹ tests 10
ℹ suites 2
ℹ pass 10
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 405.648285
```